### PR TITLE
Add initial README for RPP Data Objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# RPP - RESTful Provisioning Protocol (RPP) Data Objects
+
+This document defines data objects for the [RESTful Provisioning Protocol](https://datatracker.ietf.org/wg/rpp/about/) (RPP) and sets up IANA RPP Data Object Registry to and catalogue them.
+
+Contributions in the form of a Pull Request are welcome.
+
+[Plaintext](https://pawel-kow.github.io/draft-kowalik-rpp-data-objects/draft-kowalik-rpp-data-objects.txt)  
+[HTML](https://pawel-kow.github.io/draft-kowalik-rpp-data-objects/draft-kowalik-rpp-data-objects.html)  
+[PDF](https://pawel-kow.github.io/draft-kowalik-rpp-data-objects/draft-kowalik-rpp-data-objects.pdf)  
+
+## Contributing
+
+See the
+[guidelines for contributions](https://ietf-wg-rpp.github.io/rpp-requirements/blob/main/CONTRIBUTING.md).
+
+Pull requests are very much appreciated.
+
+## Build
+
+Requirements:
+
+- [mmark](https://mmark.miek.nl/)
+- [xml2rfc](https://github.com/ietf-tools/xml2rfc#installation)
+
+The document can be compiled using:
+
+```bash
+cd src
+make all
+```


### PR DESCRIPTION
This README defines data objects for the RESTful Provisioning Protocol and provides contribution guidelines and build instructions.